### PR TITLE
Fix delayed start

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -56,11 +56,11 @@
     ```
     00000CB8  00 00 00 00 ac f4 19 00  58 10 46 00 00 00 00 0d   ........ X.F.....
     ```
-First byte is the bool flag "delayed" ; if 0 : scan begins now (rest of the struct is ignored), if 1, scan begins at specified time (shortened version of struct netdaq_time)
+First uint32 (big-endian) is the bool flag "delayed" ; if 0 : scan begins now (rest of the struct is ignored), if 1, scan begins at specified time (shortened version of struct netdaq_time)
 ```
 struct start_request {
-	u8 delayed_flag;	// 1 if delayed
 	u8 padding[3];	//set to 0
+	u8 delayed_flag;	// 1 if delayed
 
 	u8 hours;
 	u8 minutes;

--- a/lib/netdaq.py
+++ b/lib/netdaq.py
@@ -423,10 +423,9 @@ class NetDAQ:
             pass
 
     async def start(self, start: datetime | None = None) -> None:
-        # TODO: Start does not seem to work just yet
         if start:
             packet = bytes([
-                0x01, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x01,
             ]) + make_time(start) + NULL_INT
         else:
             packet = 4 * NULL_INT


### PR DESCRIPTION
Ah, I missed a call to `ntohl` in the dll, and looking at the firmware it became obvious I got the endianness wrong on the 'delayed_start' field. It's a uint32_t big-endian.

Closes #60 